### PR TITLE
Remove shadow on Android

### DIFF
--- a/src/MaterialDesignControls/ControlsMaterial3/MaterialDivider.cs
+++ b/src/MaterialDesignControls/ControlsMaterial3/MaterialDivider.cs
@@ -18,7 +18,7 @@ namespace Plugin.MaterialDesignControls.Material3
                 _initialized = true;
                 Initialize();
             }
-
+            Xamarin.Forms.PlatformConfiguration.AndroidSpecific.VisualElement.SetElevation(this, 0);
         }
 
         #endregion Constructor


### PR DESCRIPTION
On Android, divider displayed shadow if added to a container that had previus elements with shadow